### PR TITLE
Fixed build agains lens >= 4.0

### DIFF
--- a/Text/XML/Lens.hs
+++ b/Text/XML/Lens.hs
@@ -141,10 +141,10 @@ attrs f e = fmap (\x -> e { elementAttributes = x }) $ f $ elementAttributes e
 nodes :: Lens' Element [Node]
 nodes f e = fmap (\x -> e { elementNodes = x }) $ f $ elementNodes e
 
-attr :: Name -> IndexedTraversal' Name Element Text
+attr :: Name -> Traversal' Element Text
 attr n = attrs . ix n
 
-attribute :: Name -> IndexedLens' Name Element (Maybe Text)
+attribute :: Name -> Lens' Element (Maybe Text)
 attribute n = attrs . at n
 
 -- | Traverse itself with its all children.　Rewriting subnodes of each children will break a traversal law.

--- a/xml-lens.cabal
+++ b/xml-lens.cabal
@@ -1,5 +1,5 @@
 name:                xml-lens
-version:             0.1.4
+version:             0.1.5
 synopsis:            Lenses, traversals, prisms for xml-conduit
 description:         Lens-based DOM selector
 homepage:            https://github.com/fumieval/xml-lens
@@ -20,4 +20,4 @@ library
   default-language:   Haskell2010
   ghc-options: -Wall
   exposed-modules:     Text.XML.Lens
-  build-depends:       base ==4.*, lens >= 3.8 && < 4.2, containers >= 0.4.0 && < 0.6, text == 0.11.*, xml-conduit >= 1.1 && < 1.3
+  build-depends:       base ==4.*, lens >= 4.0 && < 4.2, containers >= 0.4.0 && < 0.6, text == 0.11.*, xml-conduit >= 1.1 && < 1.3


### PR DESCRIPTION
Hello!

Old version of xml-lens failed to build against lens >= 4.0 due to significant changes in indexed traversals and lenses. That was just a matter of changing top-level type signatures, so hopefully nothing got broken except lens-3.\* compatibility. I've reflected that in the cabal file and increased version number.
