### PR TITLE
Allow xml-conduit 1.9

### DIFF
--- a/xml-lens.cabal
+++ b/xml-lens.cabal
@@ -25,5 +25,5 @@ library
     , lens >= 4.0 && < 5
     , containers >= 0.4.0 && < 0.7
     , text >= 0.7 && <2
-    , xml-conduit >= 1.1 && < 1.9
+    , xml-conduit >= 1.1 && < 1.10
     , case-insensitive


### PR DESCRIPTION
Sorry for making another PR right after #8! I initially bumped the constraint on `xml-conduit` up to `< 1.9` because version 1.9.0.0 is unpreferred on Hackage. However it is in the latest Stackage nightly. That makes using this package with that resolver a little annoying because you'll run into this error:

```
In the dependencies for xml-lens-0.1.6.3:
    xml-conduit-1.9.0.0 from stack configuration does not match
    >=1.1 && <1.9  (latest matching version is 1.8.0.1)
```