### PR TITLE
Build with GHC 9

### DIFF
--- a/Text/XML/Lens.hs
+++ b/Text/XML/Lens.hs
@@ -175,7 +175,7 @@ named n f s
 
 -- | Old name for 'named'
 ell :: Text -> Traversal' Element Element
-ell = named . CI.mk
+ell n = named $ CI.mk n
 
 -- | Traverse elements which has the specified name.
 el :: Name -> Traversal' Element Element


### PR DESCRIPTION
Eta expansion should be performed in order to build package with GHC 9.0 (due to simplified subsumption).
This PR is intented to fix such builds.