### PR TITLE
Allow xml-conduit 1.10

### DIFF
--- a/xml-lens.cabal
+++ b/xml-lens.cabal
@@ -28,5 +28,5 @@ library
     , lens >= 4.0 && < 5.4
     , containers >= 0.4.0 && < 0.7
     , text >= 0.7 && < 1.3 || >= 2 && < 2.1
-    , xml-conduit >= 1.1 && < 1.10
+    , xml-conduit >= 1.1 && < 1.11
     , case-insensitive


### PR DESCRIPTION
I've tested this locally under ghc 9.6 and 9.8.