### PR TITLE
Allow containers 0.7

### DIFF
--- a/xml-lens.cabal
+++ b/xml-lens.cabal
@@ -25,13 +25,8 @@ library
   ghc-options: -Wall
   exposed-modules:     Text.XML.Lens
   build-depends:       base ==4.*
-    , lens >= 4.0 && < 5.4
-    , containers >= 0.4.0 && < 0.7
-<<<<<<< allow-text-2-1
-    , text >= 0.7 && < 1.3 || >= 2 && < 2.2
-    , xml-conduit >= 1.1 && < 1.10
-=======
-    , text >= 0.7 && < 1.3 || >= 2 && < 2.1
-    , xml-conduit >= 1.1 && < 1.11
->>>>>>> master
     , case-insensitive
+    , containers >= 0.4.0 && < 0.8
+    , lens >= 4.0 && < 5.4
+    , text >= 0.7 && < 1.3 || >= 2 && < 2.2
+    , xml-conduit >= 1.1 && < 1.11


### PR DESCRIPTION
This library compiles fine with `containers-0.7`. Tested with `cabal build --constraint "containers == 0.7" -w ghc-9.10.2`